### PR TITLE
fix(player/registry): surface real error instead of generic fallback

### DIFF
--- a/internal/player/registry.go
+++ b/internal/player/registry.go
@@ -43,6 +43,7 @@ func (r *Registry) PlayWithSources(sources []model.PlaybackSource, media model.R
 	}
 	order := r.preferredPlayers(preferred)
 
+	var lastErr error
 	for _, p := range order {
 		logging.Debugf("PlayWithSources: trying player=%s available=%t", p.Name(), p.Available())
 		// If this is the explicitly preferred player, we try it even if it says it's unavailable,
@@ -58,10 +59,14 @@ func (r *Registry) PlayWithSources(sources []model.PlaybackSource, media model.R
 				return result, nil
 			}
 			logging.Warnf("PlayWithSources: player %s failed: %v", p.Name(), err)
+			lastErr = err
 		} else {
 			logging.Infof("PlayWithSources: player %s succeeded", p.Name())
 			return result, nil
 		}
+	}
+	if lastErr != nil {
+		return PlaybackResult{}, lastErr
 	}
 	return PlaybackResult{}, fmt.Errorf("no supported player found")
 }


### PR DESCRIPTION
When mpv was found but all playback attempts failed, the real error was being silently dropped and the user got the unhelpful "no supported player found" message instead.

Fix tracks `lastErr` across the player loop and returns it if at least one player was tried. The generic fallback is kept for when no player is available at all.