### PR TITLE
ci: replace custom build workflow with goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,3 +32,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+
+      - name: Trigger apt repo update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: Dhairya3391/kari-apt
+          event-type: release-published

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,32 +3,15 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
 
 jobs:
-  build:
-    name: Build (${{ matrix.os }}/${{ matrix.arch }})
+  goreleaser:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - os: linux
-            arch: amd64
-          - os: linux
-            arch: arm64
-          - os: windows
-            arch: amd64
-          - os: windows
-            arch: arm64
-          - os: darwin
-            arch: amd64
-          - os: darwin
-            arch: arm64
-          - os: android
-            arch: arm64
-
+    permissions:
+      contents: write
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -40,40 +23,12 @@ jobs:
           cache: true
           cache-dependency-path: go.sum
 
-      - name: Build
-        run: |
-          chmod +x build.sh
-          ./build.sh target ${{ matrix.os }} ${{ matrix.arch }}
-
-      - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
         with:
-          name: kari-${{ matrix.os }}-${{ matrix.arch }}
-          path: kari*
-          if-no-files-found: error
-
-  release:
-    name: Create Release
-    needs: build
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: ./artifacts
-          pattern: kari-*
-          merge-multiple: true
-
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: ${{ github.ref_name }}
-          generate_release_notes: true
-          files: ./artifacts/*
+          distribution: goreleaser
+          version: "~> 2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,127 @@
+version: 2
+
+project_name: kari
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: kari
+    main: ./cmd/kari
+    binary: kari
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X kari/internal/app.Version={{ .Version }}
+      - -X kari/internal/app.Commit={{ .Commit }}
+      - -X kari/internal/app.Date={{ .Date }}
+
+  - id: android
+    main: ./cmd/kari
+    binary: kari
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - android
+    goarch:
+      - arm64
+    flags:
+      - -trimpath
+      - -buildmode=pie
+    ldflags:
+      - -s -w
+      - -X kari/internal/app.Version={{ .Version }}
+      - -X kari/internal/app.Commit={{ .Commit }}
+      - -X kari/internal/app.Date={{ .Date }}
+
+archives:
+  - id: archive
+    ids: [kari]
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats: [tar.gz]
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+    files:
+      - LICENSE
+
+  - id: binary
+    ids: [kari, android]
+    name_template: "{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}"
+    formats: [binary]
+
+checksum:
+  name_template: checksums.txt
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-test"
+
+nfpms:
+  - id: packages
+    ids: [kari]
+    package_name: kari
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    homepage: https://github.com/Dhairya3391/kari
+    description: Terminal-based media browser and streamer
+    maintainer: Dhairya
+    license: MIT
+    formats:
+      - deb
+      - rpm
+      - apk
+    bindir: /usr/bin
+
+homebrew_casks:
+  - name: kari
+    ids: [archive]
+    binaries: [kari]
+    repository:
+      owner: Dhairya3391
+      name: homebrew-kari
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    homepage: https://github.com/Dhairya3391/kari
+    description: Terminal-based media browser and streamer
+    license: MIT
+
+scoops:
+  - name: kari
+    ids: [archive]
+    repository:
+      owner: Dhairya3391
+      name: scoop-kari
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    homepage: https://github.com/Dhairya3391/kari
+    description: Terminal-based media browser and streamer
+    license: MIT
+
+release:
+  prerelease: auto
+  header: |
+    ## Kari {{ .Version }}
+
+changelog:
+  use: github
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^chore:"
+      - "^test:"
+      - "^ci:"

--- a/README.md
+++ b/README.md
@@ -42,9 +42,20 @@ Type a query, press Space, pick a result.
 
 ## Installation
 
-### Prerequisites
+### Package managers
 
-- **Go 1.26+** — [Install Go](https://go.dev/doc/install)
+| Platform | Command | 
+| --- | --- |
+| **macOS** | `brew install Dhairya3391/kari/kari` |
+| **Linux** | `sudo apt install kari` — [set up the repo first](#apt-repo-setup) |
+| **Linux** | `sudo dpkg -i kari_*.deb` — grab a `.deb` from the [latest release](https://github.com/Dhairya3391/kari/releases/latest) |
+| **Windows** | `scoop bucket add kari https://github.com/Dhairya3391/scoop-kari && scoop install kari` |
+| **Android (Termux)** | `pkg install kari` — [pending upstream](https://github.com/termux/termux-packages) |
+| **Any OS** | `go install github.com/Dhairya3391/kari/cmd/kari@latest` |
+
+Or use the self-updater: `./kari -u` fetches the latest binary from GitHub releases.
+
+### Prerequisites
 
 At least one media player in `$PATH`:
 
@@ -76,7 +87,26 @@ The binary lands in the current directory as `./kari`.
 
 ### Pre-built binaries
 
-If you don't want to install Go, grab a binary from the [releases page](https://github.com/Dhairya3391/kari/releases).
+Every [release](https://github.com/Dhairya3391/kari/releases) includes binaries for:
+
+| OS | amd64 | arm64 |
+| --- | --- | --- |
+| Linux | ✅ | ✅ |
+| macOS | ✅ | ✅ |
+| Windows | ✅ | ✅ |
+| Android | — | ✅ |
+
+Grab the one for your platform, make it executable, and run.
+
+### Apt repo setup
+
+```bash
+echo "deb [trusted=yes] https://dhairya3391.github.io/kari-apt /" | sudo tee /etc/apt/sources.list.d/kari.list
+sudo apt update
+sudo apt install kari
+```
+
+<!-- Once accepted into official repos, replace the above with just `sudo apt install kari`. -->
 
 ## Configuration
 

--- a/scripts/termux/build.sh
+++ b/scripts/termux/build.sh
@@ -2,12 +2,17 @@ TERMUX_PKG_HOMEPAGE=https://github.com/Dhairya3391/kari
 TERMUX_PKG_DESCRIPTION="Terminal-based media browser and streamer (anime, movies, TV)"
 TERMUX_PKG_LICENSE=MIT
 TERMUX_PKG_MAINTAINER="@Dhairya3391"
-TERMUX_PKG_VERSION=1.3.0
+TERMUX_PKG_VERSION=1.3.4
 TERMUX_PKG_SRCURL=https://github.com/Dhairya3391/kari/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
 TERMUX_PKG_SHA256=SKIP
 TERMUX_PKG_BUILD_IN_SRC=true
 
+termux_step_setup_variables() {
+	:
+}
+
 termux_step_make() {
+	termux_setup_golang
 	cd "$TERMUX_PKG_SRCDIR"
 	go build \
 		-trimpath \

--- a/scripts/termux/build.sh
+++ b/scripts/termux/build.sh
@@ -1,0 +1,22 @@
+TERMUX_PKG_HOMEPAGE=https://github.com/Dhairya3391/kari
+TERMUX_PKG_DESCRIPTION="Terminal-based media browser and streamer (anime, movies, TV)"
+TERMUX_PKG_LICENSE=MIT
+TERMUX_PKG_MAINTAINER="@Dhairya3391"
+TERMUX_PKG_VERSION=1.3.0
+TERMUX_PKG_SRCURL=https://github.com/Dhairya3391/kari/archive/refs/tags/v${TERMUX_PKG_VERSION}.tar.gz
+TERMUX_PKG_SHA256=SKIP
+TERMUX_PKG_BUILD_IN_SRC=true
+
+termux_step_make() {
+	cd "$TERMUX_PKG_SRCDIR"
+	go build \
+		-trimpath \
+		-buildmode=pie \
+		-ldflags="-s -w -X kari/internal/app.Version=$TERMUX_PKG_VERSION -X kari/internal/app.Commit=$(git rev-parse --short HEAD)" \
+		-o kari \
+		./cmd/kari
+}
+
+termux_step_make_install() {
+	install -Dm700 kari "$TERMUX_PREFIX/bin/kari"
+}


### PR DESCRIPTION
Replace the old matrix-based build workflow with GoReleaser for automated release management.

**What this PR does:**

- `.goreleaser.yaml` — automated builds (linux/darwin/windows/android), archives, nFPM packages (.deb/.rpm/.apk), Homebrew Cask publishing, Scoop manifest publishing
- `.github/workflows/release.yml` — single goreleaser action step, apt repo dispatch on completion
- `scripts/termux/build.sh` — Termux package build script for PR submission
- `README.md` — added Homebrew, Scoop, apt, and go install methods

**Created infrastructure:**

| Type | Repo/Link | Status |
|---|---|---|
| **Homebrew tap** | [Dhairya3391/homebrew-kari](https://github.com/Dhairya3391/homebrew-kari) | ✅ Active — formula auto-pushed on release |
| **Scoop bucket** | [Dhairya3391/scoop-kari](https://github.com/Dhairya3391/scoop-kari) | ✅ Active — manifest auto-pushed on release |
| **Apt repo** | [Dhairya3391/kari-apt](https://github.com/Dhairya3391/kari-apt) | ✅ Active — served via GitHub Pages, auto-updated on release |

**Submitted upstream PRs:**

| Target | PR | Status |
|---|---|---|
| **Homebrew/homebrew-core** | [#291429](https://github.com/Homebrew/homebrew-core/pull/291429) | ⏳ Submitted |
| **ScoopInstaller/Extras** | [#18231](https://github.com/ScoopInstaller/Extras/pull/18231) | ⏳ Submitted |
| **termux/termux-packages** | [#30441](https://github.com/termux/termux-packages/pull/30441) | ⏳ Submitted |

**Install commands once upstream PRs are accepted:**

```bash
# macOS
brew install kari

# Linux
sudo apt install kari

# Windows
scoop install kari

# Android (Termux)
pkg install kari
```

**Upstream-independent install (works now):**

```bash
# macOS (custom tap)
brew install Dhairya3391/kari/kari

# Linux (custom apt repo)
echo "deb [trusted=yes] https://dhairya3391.github.io/kari-apt /" | sudo tee /etc/apt/sources.list.d/kari.list
sudo apt update && sudo apt install kari

# Windows (custom bucket)
scoop bucket add kari https://github.com/Dhairya3391/scoop-kari && scoop install kari

# Any OS
go install github.com/Dhairya3391/kari/cmd/kari@latest
```

**Tested:** `v0.0.0-test` release verified end-to-end — 19 assets, Homebrew tap push, Scoop bucket push, all confirmed.