### PR TITLE
fix(player): use --sub-files instead of --sub-file for IINA compatibility

### DIFF
--- a/internal/player/mpv.go
+++ b/internal/player/mpv.go
@@ -278,7 +278,7 @@ func appendSubtitleArgs(args []string, subtitleFiles []string) []string {
 		if strings.TrimSpace(sub) != "" {
 			sub = strings.ReplaceAll(sub, `\`, `/`)
 			logging.Debugf("appendSubtitleArgs: adding sub-file=%q", sub)
-			args = append(args, "--sub-file="+sub)
+			args = append(args, "--sub-files="+sub)
 		}
 	}
 	return args


### PR DESCRIPTION
IINA doesn't support mpv option aliases like `--sub-file` (singular), so subtitles were silently ignored. Changed to `--sub-files` (plural) which is the canonical mpv option name and works in both MPV and IINA.

Fixes subtitle loading in IINA when playing through kari.